### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#XSSSNIPER
+# XSSSNIPER
 
 xsssniper is an handy xss discovery tool with mass scanning functionalities.
 
-##Usage:
+## Usage:
 
     Usage: xsssniper.py [options]
 
@@ -50,7 +50,7 @@ Analyze target page javascripts (embedded and linked) to search for common sinks
     
     $ python xsssniper.py -u "http://target.com" --dom
 
-##Thanks:
+## Thanks:
 
 * Miroslav Stamparm 
 * Claudio Telmon


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
